### PR TITLE
Fix warnings in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,9 +19,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "GameKitUI",
-            dependencies: [],
-            exclude: ["../../MetaData", "../../Examples"]),
+            name: "GameKitUI"),
         .testTarget(
             name: "GameKitUITests",
             dependencies: ["GameKitUI"])

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "GameKitUI",
-    platforms: [ .iOS(SupportedPlatform.IOSVersion.v13),
-                 .macOS(SupportedPlatform.MacOSVersion.v10_15),
-                 .tvOS(SupportedPlatform.TVOSVersion.v13),
-                 .watchOS(SupportedPlatform.WatchOSVersion.v6)
+    platforms: [ .iOS(.v13),
+                 .macOS(.v10_15),
+                 .tvOS(.v13),
+                 .watchOS(.v6)
     ],
     products: [
         .library(
@@ -21,7 +21,7 @@ let package = Package(
         .target(
             name: "GameKitUI",
             dependencies: [],
-            exclude: ["MetaData", "Examples"]),
+            exclude: ["../../MetaData", "../../Examples"]),
         .testTarget(
             name: "GameKitUITests",
             dependencies: ["GameKitUI"])


### PR DESCRIPTION
Hi @smuellner 

Thanks for this package 😁 

I've checked it out and there are some warnings when resolving the package graph, specifically:

> Invalid Exclude '/<...>/GameKitUI/Sources/GameKitUI/MetaData': File not found.
> Invalid Exclude '/<...>/GameKitUI/Sources/GameKitUI/Examples': File not found.

As per documentation: 

> - path: The custom path for the target. By default, targets will be looked up in the <package-root>/Sources/<target-name> directory. (...)
> - exclude: A list of paths to exclude from being considered source files. This path is relative to the target's directory.

Originally I wanted to update the paths to exclude folders from the root but I think it's not needed as the path to the target is `<package-root>/Sources/<target-name>`, so it shouldn't cover `MetaData` and `Examples` folders.

I verified that with the following fix the warnings are gone 😉 